### PR TITLE
Updated plugin dependencies

### DIFF
--- a/nbsbt-core/src/main/scala/org/netbeans/nbsbt/core/NetBeansPlugin.scala
+++ b/nbsbt-core/src/main/scala/org/netbeans/nbsbt/core/NetBeansPlugin.scala
@@ -30,9 +30,9 @@ import sbt.{
   State,
   TaskKey
 }
-import sbt.Keys.{ baseDirectory, commands }
+import sbt.Keys.{baseDirectory, commands}
 import scala.util.control.Exception
-import scala.xml.{ Attribute, Elem, MetaData, Node, Null, Text }
+import scala.xml.{Attribute, Elem, MetaData, Node, Null, Text}
 import scala.xml.transform.RewriteRule
 import scalariform.formatter.preferences.IFormattingPreferences
 
@@ -44,7 +44,8 @@ trait NetBeansPlugin {
     import NetBeansKeys._
     Seq(
       commandName := "netbeans",
-      commands <+= (commandName)(NetBeans.netbeansCommand))
+      commands <+= (commandName)(NetBeans.netbeansCommand)
+    )
   }
 
   object NetBeansKeys {
@@ -52,64 +53,79 @@ trait NetBeansPlugin {
 
     val executionEnvironment: SettingKey[Option[NetBeansExecutionEnvironment.Value]] = SettingKey(
       prefix(ExecutionEnvironment),
-      "The optional NetBeans execution environment.")
+      "The optional NetBeans execution environment."
+    )
 
     val skipParents: SettingKey[Boolean] = SettingKey(
       prefix(SkipParents),
-      "Skip creating NetBeans files for parent project?")
+      "Skip creating NetBeans files for parent project?"
+    )
 
     val withSource: SettingKey[Boolean] = SettingKey(
       prefix(WithSource),
-      "Download and link sources for library dependencies?")
+      "Download and link sources for library dependencies?"
+    )
 
     val useProjectId: SettingKey[Boolean] = SettingKey(
       prefix(UseProjectId),
-      "Use the sbt project id as the NetBeans project name?")
+      "Use the sbt project id as the NetBeans project name?"
+    )
 
     @deprecated("Use classpathTransformerFactories instead!", "2.1.0")
     val classpathEntryTransformerFactory: SettingKey[NetBeansTransformerFactory[Seq[NetBeansClasspathEntry] => Seq[NetBeansClasspathEntry]]] = SettingKey(
       prefix("classpathEntryTransformerFactory"),
-      "Creates a transformer for classpath entries.")
+      "Creates a transformer for classpath entries."
+    )
 
     val classpathTransformerFactories: SettingKey[Seq[NetBeansTransformerFactory[RewriteRule]]] = SettingKey(
       prefix("classpathTransformerFactory"),
-      "Factories for a rewrite rule for the .classpath file.")
+      "Factories for a rewrite rule for the .classpath file."
+    )
 
     val projectTransformerFactories: SettingKey[Seq[NetBeansTransformerFactory[RewriteRule]]] = SettingKey(
       prefix("projectTransformerFactory"),
-      "Factories for a rewrite rule for the .project file.")
+      "Factories for a rewrite rule for the .project file."
+    )
 
     val commandName: SettingKey[String] = SettingKey(
       prefix("command-name"),
-      "The name of the command.")
+      "The name of the command."
+    )
 
     val configurations: SettingKey[Set[Configuration]] = SettingKey(
       prefix("configurations"),
-      "The configurations to take into account.")
+      "The configurations to take into account."
+    )
 
     val createSrc: SettingKey[NetBeansCreateSrc.ValueSet] = SettingKey(
       prefix("create-src"),
-      "The source kinds to be included.")
+      "The source kinds to be included."
+    )
 
     val projectFlavor: SettingKey[NetBeansProjectFlavor.Value] = SettingKey(
       prefix("project-flavor"),
-      "The flavor of project (Scala or Java) to build.")
+      "The flavor of project (Scala or Java) to build."
+    )
 
     val netbeansOutput: SettingKey[Option[String]] = SettingKey(
       prefix("netbeans-output"),
-      "The optional output for NetBeans.")
+      "The optional output for NetBeans."
+    )
 
     val preTasks: SettingKey[Seq[TaskKey[_]]] = SettingKey(
       prefix("pre-tasks"),
-      "The tasks to be evaluated prior to creating the NetBeans project definition.")
+      "The tasks to be evaluated prior to creating the NetBeans project definition."
+    )
 
     val relativizeLibs: SettingKey[Boolean] = SettingKey(
       prefix("relativize-libs"),
-      "Relativize the paths to the libraries?")
+      "Relativize the paths to the libraries?"
+    )
 
     val skipProject: SettingKey[Boolean] = SettingKey(
       prefix("skipProject"),
-      "Skip creating NetBeans files for a given project?")
+      "Skip creating NetBeans files for a given project?"
+    )
 
     private def prefix(key: String) = "netbeans-" + key
   }
@@ -232,8 +248,9 @@ trait NetBeansPlugin {
     object Identity extends NetBeansTransformerFactory[Seq[NetBeansClasspathEntry] => Seq[NetBeansClasspathEntry]] {
       import scalaz.Scalaz._
       override def createTransformer(
-        ref: ProjectRef,
-        state: State): Validation[Seq[NetBeansClasspathEntry] => Seq[NetBeansClasspathEntry]] = {
+        ref:   ProjectRef,
+        state: State
+      ): Validation[Seq[NetBeansClasspathEntry] => Seq[NetBeansClasspathEntry]] = {
         val transformer = (entries: Seq[NetBeansClasspathEntry]) => entries
         transformer.success
       }

--- a/nbsbt-core/src/main/scala/org/netbeans/nbsbt/core/NetBeansSDTConfig.scala
+++ b/nbsbt-core/src/main/scala/org/netbeans/nbsbt/core/NetBeansSDTConfig.scala
@@ -52,7 +52,8 @@ private trait NetBeansSDTConfig {
     TakesArg("Yrecursion"),
     Flag("Yself-in-annots"),
     ColonSeparated("Ystruct-dispatch"),
-    Flag("Ywarn-dead-code"))
+    Flag("Ywarn-dead-code")
+  )
 
   private sealed trait SDTOption {
     def name: String

--- a/nbsbt-core/src/main/scala/org/netbeans/nbsbt/core/package.scala
+++ b/nbsbt-core/src/main/scala/org/netbeans/nbsbt/core/package.scala
@@ -40,7 +40,7 @@ import sbt.{
 }
 import sbt.Load.BuildStructure
 import sbt.complete.Parser
-import scalaz.{ Equal, NonEmptyList, Validation => ScalazValidation }
+import scalaz.{Equal, NonEmptyList, Validation => ScalazValidation}
 import scalaz.Scalaz._
 
 package object core {

--- a/nbsbt-plugin/src/main/scala/org/netbeans/nbsbt/plugin/NetBeansPlugin.scala
+++ b/nbsbt-plugin/src/main/scala/org/netbeans/nbsbt/plugin/NetBeansPlugin.scala
@@ -18,8 +18,8 @@
 
 package org.netbeans.nbsbt.plugin
 
-import org.netbeans.nbsbt.core.{ NetBeansPlugin => CoreNetBeansPlugin }
-import sbt.{ Plugin, Setting }
+import org.netbeans.nbsbt.core.{NetBeansPlugin => CoreNetBeansPlugin}
+import sbt.{Plugin, Setting}
 
 object NetBeansPlugin extends Plugin with CoreNetBeansPlugin {
   override def settings: Seq[Setting[_]] = CoreNetBeansPlugin.netbeansSettings

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -21,7 +21,7 @@ object Build extends Build {
       libraryDependencies ++= Seq(
         "org.scalaz" %% "scalaz-core" % "7.0.2",
         "org.scalaz" %% "scalaz-effect" % "7.0.2"),
-      addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")))
+      addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")))
 
   lazy val nbsbtPlugin = Project(
     "nbsbt-plugin",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.9

--- a/project/maven.sbt
+++ b/project/maven.sbt
@@ -1,0 +1,1 @@
+addMavenResolverPlugin

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,10 @@
 
 libraryDependencies <+= (sbtVersion)("org.scala-sbt" % "scripted-plugin" % _)
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.7.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.0")
+// https://github.com/sbt/sbt-scalariform
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+
+
+resolvers ++= Seq(Resolver.mavenLocal, Resolver.sonatypeRepo("releases"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.4"
+version in ThisBuild := "1.1.5"


### PR DESCRIPTION
Updated to more current plugins. It now works correctly with projects that use sbt-scalariform > 1.4.0.

This is a fix for an issue where my projects were running sbt-scalariform 1.6.0. Adding nbsbt to my global plugins would subsequently prevent any of my projects from opening by throwing `java.lang.ClassCastException: Cannot cast com.typesafe.sbt.SbtScalariform$ to sbt.AutoPlugin` whenever the `sbt` command was run. This was due to a class between the versions of sbt-scalariform.

This fix addresses that issue. Tested with Netbeans 8.1.
